### PR TITLE
fix: typescript v5 deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TSConfigs for Vue projects to extend.
 
-Requires TypeScript >= 4.5.
+Requires TypeScript >= 5.
 
 Install:
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/vuejs/tsconfig#readme",
   "peerDependencies": {
-    "@types/node": "*"
+    "@types/node": "*",
+    "typescript": "^5.0.2"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,6 @@
     "noImplicitThis": true,
     "strict": true,
 
-    // Required in Vite
-    "isolatedModules": true,
     // Enforce using `import type` instead of `import` for types
     "verbatimModuleSyntax": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,8 @@
 
     // Required in Vite
     "isolatedModules": true,
-    // For `<script setup>`
-    // See <https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#preserve-value-imports>
-    "preserveValueImports": true,
     // Enforce using `import type` instead of `import` for types
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
 
     // A few notes:
     // - Vue 3 supports ES2016+
@@ -35,6 +32,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     // See <https://github.com/vuejs/vue-cli/pull/5688>
-    "skipLibCheck": true,
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     // See <https://github.com/vuejs/vue-cli/pull/5688>
-    "skipLibCheck": true
+    "skipLibCheck": true,
   }
 }


### PR DESCRIPTION
Hello,
I tried to upgrade one of my Vue3 projects using `@vue/tsconfig` to `typescript` v5. Unfortunately they introduced deprecations regarding `--importsNotUsedAsValues` and `--preserveValueImports` in favour of the newly introduced `--verbatimModuleSyntax` flag.

Of course there is a temporary workaround to just ignore those deprecations:

```json
{
  "compilerOptions": {
    "ignoreDeprecations": "5.0"
  }
}
```

This PR probably will result in a breaking change, since the new flag is only available in `typescript` v5.

Fixes #6 