### PR TITLE
fix(isolatedModules): Remove redundant isolatedModules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,6 @@
     "noImplicitThis": true,
     "strict": true,
 
-    // Required in Vite
-    "isolatedModules": true,
-
     // <https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax>
     // Any imports or exports without a type modifier are left around. This is important for `<script setup>`.
     // Anything that uses the type modifier is dropped entirely.
@@ -51,6 +48,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     // See <https://github.com/vuejs/vue-cli/pull/5688>
-    "skipLibCheck": true,
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     // See <https://github.com/vuejs/vue-cli/pull/5688>
-    "skipLibCheck": true
+    "skipLibCheck": true,
   }
 }


### PR DESCRIPTION
# Issue

The following warning is shown when using version 0.3.2:

`error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.`

<img width="958" alt="Screenshot 2023-05-01 at 11 36 03" src="https://user-images.githubusercontent.com/4020037/235436013-e3126fc3-4c32-49ea-820c-d41167871b8a.png">

As seen in https://github.com/microsoft/TypeScript/issues/53601#issuecomment-1498239566, isolatedModules is redundant when using `verbatimModuleSyntax: true`, and therefore throws this warning.

# Solution

By removing `isolatedModules` from `tsconfig.json` the warning is gone.