### PR TITLE
Remove `"isolatedModules": true`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,6 @@
     "noImplicitThis": true,
     "strict": true,
 
-    // Required in Vite
-    "isolatedModules": true,
-
     // <https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax>
     // Any imports or exports without a type modifier are left around. This is important for `<script setup>`.
     // Anything that uses the type modifier is dropped entirely.


### PR DESCRIPTION
It is implied by `verbatimModuleSyntax` and causes an error:
```
error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
```