### PR TITLE
fix: add peer dep to typescript v5.x in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "homepage": "https://github.com/vuejs/tsconfig#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "typescript": "5.x"
   }
 }


### PR DESCRIPTION
tsconfig is using typescript v5 features and doesn't work with v4.