### PR TITLE
feat: disable `libReplacement` for better performance

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,6 +52,7 @@
     // Recommended
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "libReplacement": false,
     // See <https://github.com/vuejs/vue-cli/pull/5688>
     "skipLibCheck": true,
   }


### PR DESCRIPTION
This PR disables the flag `libReplacement` in `tsconfig.json` for better performance.

`libReplacement` is introduced in TS 5.8. Now it's enabled by default, but it will default to false when TS 6.0.

Most of people don't need it enabled.

Refs:

- https://github.com/microsoft/TypeScript/pull/60829