### PR TITLE
feat!: enable `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,11 @@
     "noImplicitThis": true,
     "strict": true,
 
+    // See <https://www.semver-ts.org/formal-spec/5-compiler-considerations.html#strictness>
+    // These 2 options are also part of the recommended tsconfig as of TS 5.9
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
     // <https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax>
     // Any imports or exports without a type modifier are left around. This is important for `<script setup>`.
     // Anything that uses the type modifier is dropped entirely.

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -8,6 +8,8 @@
     // Libraries generally require more strict type accuracy.
     // For example, its types must be compatible with the Vue types.
     // So we don't want to skip the type checking of its dependencies.
-    "skipLibCheck": false
+    "skipLibCheck": false,
+
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -9,7 +9,5 @@
     // For example, its types must be compatible with the Vue types.
     // So we don't want to skip the type checking of its dependencies.
     "skipLibCheck": false,
-
-    "noUncheckedIndexedAccess": true
   }
 }


### PR DESCRIPTION
See https://www.semver-ts.org/formal-spec/5-compiler-considerations.html#strictness for the arguments for turning on noUncheckedIndexedAccess for libraries.

In short, it helps prevent shipping accidental breaking type changes to library consumers.

The link also suggests turning on `exactOptionalPropertyTypes`~~, but I still have doubts about it, as it would not be helpful without a specific coding style, which is hard to enforce~~. By moving both options to the baseline `tsconfig.json`, we can ensure strictness across the ecosystem.